### PR TITLE
Correció ortogràfica al home

### DIFF
--- a/dictionaries/ca.json
+++ b/dictionaries/ca.json
@@ -22,7 +22,7 @@
     "members": {
       "title_1": "Coneix la",
       "title_2": "comunitat",
-      "subtitle": "Descobreix la talentosa gent que existeix a Girona. Som molts més dels què creus!"
+      "subtitle": "Descobreix la talentosa gent que existeix a Girona. Som molts més dels que creus!"
     },
     "blog": {
       "title_1": "Descobreix els nostres",


### PR DESCRIPTION
A gironajs.com/dictionaries/ca.json hi havia un error ortogràfic on el què final no va accentuat.